### PR TITLE
Have CI separate the lint and build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    container: gradle:jdk11
+    container: wpilib/roborio-cross-ubuntu:2022-18.04
     steps:
       - uses: actions/checkout@v2
       - run: |
           cd takoyaki
-          ./gradlew build
+          ./gradlew assemble
 
   lint:
     name: Run checkstyle linter


### PR DESCRIPTION
Previously, `./gradlew build` both builds and lints, which does not achieve the separation between the two desired steps.

Also, updates the pipeline to use the official WPILib container for the build step. The lint step still uses the default image since it doesn't need to closely resemble the RIO.